### PR TITLE
feat: Enable users to add and view their own properties

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';
 import PaymentPage from './pages/PaymentPage';
+import AddPropertyPage from './pages/AddPropertyPage'; // Added import
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/payment" element={<PaymentPage />} />
+              <Route path="/add-property" element={<AddPropertyPage />} /> {/* Added route */}
         </Routes>
       </Layout>
     </Router>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Search, Globe, Menu, User } from 'lucide-react';
 import Logo from './Logo';
 import SearchBar from './SearchBar';
@@ -39,6 +40,9 @@ const Header: React.FC<HeaderProps> = ({ scrolled, toggleMobileMenu }) => {
           </div>
           
           <div className="flex items-center gap-1.5">
+            <Link to="/add-property" className="hidden md:flex items-center rounded-full px-3 py-1.5 text-xs font-medium hover:bg-gray-100 transition-colors">
+              List your property
+            </Link>
             <button className="hidden md:flex items-center rounded-full border px-2 py-1 hover:shadow-sm transition-shadow">
               <Globe size={14} className="mr-1" />
               <span className="text-xs">EN</span>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -28,7 +28,7 @@ const MobileNav: React.FC<MobileNavProps> = ({ isOpen, onClose }) => {
               <LogIn size={24} className="mr-4" />
               <span className="font-medium">Log in</span>
             </a>
-            <a href="#" className="flex items-center py-3 border-b border-gray-100">
+            <a href="/add-property" className="flex items-center py-3 border-b border-gray-100" onClick={onClose}>
               <Plus size={24} className="mr-4" />
               <span className="font-medium">List your space</span>
             </a>

--- a/src/data/userListings.ts
+++ b/src/data/userListings.ts
@@ -1,0 +1,49 @@
+import type { Listing } from './spreadsheetData';
+
+const USER_LISTINGS_KEY = 'userAddedListings';
+
+// Helper to get all listings from localStorage
+export function getUserListings(): Listing[] {
+  try {
+    const listingsJson = localStorage.getItem(USER_LISTINGS_KEY);
+    if (listingsJson) {
+      return JSON.parse(listingsJson) as Listing[];
+    }
+  } catch (error) {
+    console.error('Error reading user listings from localStorage:', error);
+  }
+  return [];
+}
+
+// Helper to save all listings to localStorage
+function saveUserListings(listings: Listing[]): void {
+  try {
+    localStorage.setItem(USER_LISTINGS_KEY, JSON.stringify(listings));
+  } catch (error) {
+    console.error('Error saving user listings to localStorage:', error);
+  }
+}
+
+// Function to add a new listing
+// It will generate a new negative ID to avoid conflicts with existing listings
+export function addUserListing(newListingData: Omit<Listing, 'id'>): Listing {
+  const userListings = getUserListings();
+
+  // Generate a new ID (negative to distinguish from sheet/CSV listings)
+  let nextId = -1;
+  if (userListings.length > 0) {
+    const minId = Math.min(...userListings.map(l => l.id));
+    if (minId < 0) { // Only consider negative IDs for decrementing
+      nextId = minId - 1;
+    }
+  }
+
+  const newListingWithId: Listing = {
+    ...newListingData,
+    id: nextId,
+  };
+
+  userListings.push(newListingWithId);
+  saveUserListings(userListings);
+  return newListingWithId;
+}

--- a/src/pages/AddPropertyPage.tsx
+++ b/src/pages/AddPropertyPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { addUserListing } from '../data/userListings'; // Assuming this path is correct
+import type { Listing } from '../data/spreadsheetData'; // Assuming this path is correct
+
+const AddPropertyPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [location, setLocation] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [price, setPrice] = useState('');
+  const [amenities, setAmenities] = useState(''); // Comma-separated
+  const [rules, setRules] = useState(''); // Comma-separated
+  const [distance, setDistance] = useState('');
+  // Rating can be optional or have a default, not included in form for simplicity here
+  // Or add it if simple: const [rating, setRating] = useState('');
+
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (!title || !location || !imageUrl || !price || !amenities || !rules || !distance) {
+      setError('Please fill in all fields.');
+      return;
+    }
+
+    const priceNum = parseFloat(price);
+    if (isNaN(priceNum) || priceNum <= 0) {
+      setError('Please enter a valid price.');
+      return;
+    }
+
+    // Basic image URL validation (starts with http/https)
+    if (!imageUrl.match(/^https?:\/\/.+/)) {
+        setError('Please enter a valid image URL (starting with http:// or https://).');
+        return;
+    }
+
+    // For simplicity, rating is hardcoded or can be made dynamic
+    // User-added properties might not have a community rating initially
+    const newListingData: Omit<Listing, 'id'> = {
+      title,
+      location,
+      imageUrl,
+      price: priceNum,
+      amenities: amenities.split(',').map(a => a.trim()).filter(a => a),
+      rules: rules.split(',').map(r => r.trim()).filter(r => r),
+      distance,
+      rating: 0, // Default rating for new properties
+    };
+
+    try {
+      addUserListing(newListingData);
+      setSuccess('Property added successfully! Redirecting...');
+      setTimeout(() => {
+        navigate('/');
+      }, 2000);
+    } catch (e) {
+      console.error('Failed to add property:', e);
+      setError('Failed to add property. Please try again.');
+    }
+  };
+
+  return (
+    <div className="container-pad py-8">
+      <h1 className="text-2xl font-bold mb-6 text-center">Add Your Property</h1>
+      <form onSubmit={handleSubmit} className="max-w-lg mx-auto bg-white p-8 rounded-lg shadow-md">
+        {error && <p className="mb-4 text-red-500 bg-red-100 p-3 rounded">{error}</p>}
+        {success && <p className="mb-4 text-green-500 bg-green-100 p-3 rounded">{success}</p>}
+
+        <div className="mb-4">
+          <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+          <input type="text" id="title" value={title} onChange={e => setTitle(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="location" className="block text-sm font-medium text-gray-700 mb-1">Location</label>
+          <input type="text" id="location" value={location} onChange={e => setLocation(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700 mb-1">Image URL</label>
+          <input type="url" id="imageUrl" value={imageUrl} onChange={e => setImageUrl(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" placeholder="https://example.com/image.jpg" />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="distance" className="block text-sm font-medium text-gray-700 mb-1">Distance (e.g., '2km from center')</label>
+          <input type="text" id="distance" value={distance} onChange={e => setDistance(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="price" className="block text-sm font-medium text-gray-700 mb-1">Price per Month (INR)</label>
+          <input type="number" id="price" value={price} onChange={e => setPrice(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="amenities" className="block text-sm font-medium text-gray-700 mb-1">Amenities (comma-separated)</label>
+          <input type="text" id="amenities" value={amenities} onChange={e => setAmenities(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" placeholder="e.g., AC, WiFi, Furnished" />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="rules" className="block text-sm font-medium text-gray-700 mb-1">Rules (comma-separated)</label>
+          <input type="text" id="rules" value={rules} onChange={e => setRules(e.target.value)} required className="w-full p-2 border border-gray-300 rounded-md shadow-sm" placeholder="e.g., No smoking, Pets allowed" />
+        </div>
+
+        <button type="submit" className="w-full bg-[#FF5A5F] text-white py-2.5 rounded-md hover:bg-[#E00B41] transition-colors font-medium">
+          Add Property
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default AddPropertyPage;


### PR DESCRIPTION
This commit introduces functionality for users to add new property listings to the site.

Key changes include:

-   **Add Property Page**: A new page at `/add-property` with a form for users to submit property details (title, location, image, price, amenities, rules, distance).
-   **Local Storage for User Properties**: User-added properties are stored in the browser's localStorage. Helper functions in `src/data/userListings.ts` manage saving and retrieving these listings. User properties are assigned negative IDs to prevent conflicts with existing data.
-   **Integrated Listings**: The main property display now merges listings from the original data source (CSV/Google Sheets) with user-added properties from localStorage.
-   **Updated Navigation**: Links to the "Add Property" page have been added to the main header (for desktop) and the mobile navigation menu.
-   **Interactive Components**: Ensured existing filtering and display components work correctly with the combined dataset. The `SearchBar`'s interactivity remains visual, without full filter integration for now.

Users can now contribute their own property listings, which will be visible to them on their current browser and integrated into the existing browsing and filtering experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new page allowing users to list their property through a dedicated form.
  - Introduced navigation links in both the header and mobile menu for easy access to the property listing page.
  - User-added property listings are now supported and displayed alongside existing listings.

- **Bug Fixes**
  - Ensured mobile navigation closes when selecting the "List your space" link.

- **Chores**
  - Improved logging to reflect the inclusion of user-added listings in data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->